### PR TITLE
test: register seatplus factory guessing for browser tests

### DIFF
--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,5 +1,8 @@
 <?php
 
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
 /*
 |--------------------------------------------------------------------------
 | Test Case
@@ -12,3 +15,18 @@
 */
 
 uses(Tests\TestCase::class)->in('Browser');
+
+/*
+| The assembled app has none of the web package's Testbench factory-name
+| guessing, so model factories from the seatplus packages can't be resolved by
+| Laravel's default guessing. Map each seatplus model namespace to its package
+| factory namespace, for any browser test that uses factories (e.g. authed tests).
+*/
+beforeEach(function () {
+    Factory::guessFactoryNamesUsing(fn (string $model) => match (true) {
+        Str::startsWith($model, 'Seatplus\\Auth') => 'Seatplus\\Auth\\Database\\Factories\\'.class_basename($model).'Factory',
+        Str::startsWith($model, 'Seatplus\\Eveapi') => 'Seatplus\\Eveapi\\Database\\Factories\\'.class_basename($model).'Factory',
+        Str::startsWith($model, 'Seatplus\\Web') => 'Seatplus\\Web\\Database\\Factories\\'.class_basename($model).'Factory',
+        default => 'Database\\Factories\\'.class_basename($model).'Factory',
+    });
+})->in('Browser');


### PR DESCRIPTION
Sets `Factory::guessFactoryNamesUsing` once for the Browser suite in core's `tests/Pest.php`, mapping the seatplus model namespaces to their package factories. Web-authored browser tests that use factories (e.g. the authenticated smoke test) then resolve without repeating the mapping in each file.