### PR TITLE
test: move browser factory guessing into TestCase::setUp

### DIFF
--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,8 +1,5 @@
 <?php
 
-use Illuminate\Database\Eloquent\Factories\Factory;
-use Illuminate\Support\Str;
-
 /*
 |--------------------------------------------------------------------------
 | Test Case
@@ -12,21 +9,8 @@ use Illuminate\Support\Str;
 | packages), so Vite/manifest, @routes/@translations, providers, assets and
 | auth all work natively — unlike the web package's Testbench harness.
 |
+| Seatplus package factory-name guessing is registered in Tests\TestCase::setUp().
+|
 */
 
 uses(Tests\TestCase::class)->in('Browser');
-
-/*
-| The assembled app has none of the web package's Testbench factory-name
-| guessing, so model factories from the seatplus packages can't be resolved by
-| Laravel's default guessing. Map each seatplus model namespace to its package
-| factory namespace, for any browser test that uses factories (e.g. authed tests).
-*/
-beforeEach(function () {
-    Factory::guessFactoryNamesUsing(fn (string $model) => match (true) {
-        Str::startsWith($model, 'Seatplus\\Auth') => 'Seatplus\\Auth\\Database\\Factories\\'.class_basename($model).'Factory',
-        Str::startsWith($model, 'Seatplus\\Eveapi') => 'Seatplus\\Eveapi\\Database\\Factories\\'.class_basename($model).'Factory',
-        Str::startsWith($model, 'Seatplus\\Web') => 'Seatplus\\Web\\Database\\Factories\\'.class_basename($model).'Factory',
-        default => 'Database\\Factories\\'.class_basename($model).'Factory',
-    });
-})->in('Browser');

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,9 +2,25 @@
 
 namespace Tests;
 
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+use Illuminate\Support\Str;
 
 abstract class TestCase extends BaseTestCase
 {
-    //
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // The assembled app has no Testbench factory-name guessing, so package
+        // model factories (auth/eveapi/web) can't be resolved by Laravel's
+        // default guessing. Map each seatplus model namespace to its package
+        // factory namespace, for browser tests that use factories.
+        Factory::guessFactoryNamesUsing(fn (string $model) => match (true) {
+            Str::startsWith($model, 'Seatplus\\Auth') => 'Seatplus\\Auth\\Database\\Factories\\'.class_basename($model).'Factory',
+            Str::startsWith($model, 'Seatplus\\Eveapi') => 'Seatplus\\Eveapi\\Database\\Factories\\'.class_basename($model).'Factory',
+            Str::startsWith($model, 'Seatplus\\Web') => 'Seatplus\\Web\\Database\\Factories\\'.class_basename($model).'Factory',
+            default => 'Database\\Factories\\'.class_basename($model).'Factory',
+        });
+    }
 }


### PR DESCRIPTION
Follow-up to #237. The `beforeEach(...)->in('Browser')` form in Pest.php silently didn't register, so browser tests' `User::factory()` still hit default guessing and failed with `Class "Database\\Factories\\Seatplus\\...Factory" not found`. Moves the seatplus factory-name guessing into `Tests\TestCase::setUp()`, which runs for every browser test unambiguously, and reverts the non-working Pest.php hook.