### PR TITLE
fix: isolate tests to seatplus_testing + add browser-suite provisioning helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,15 @@ The source of truth lives in `seatplus/web`.
 
 Prerequisites: built frontend assets (`npm run build`) and the Playwright browser
 binaries. Screenshots from a run land in `tests/Browser/Screenshots/`.
+
+> ⚠️ **Dedicated test database.** These tests use `RefreshDatabase` (`migrate:fresh`),
+> so they must never run against the dev database — that would wipe it. `phpunit.xml`
+> pins the test DB to **`seatplus_testing`** (`force="true"`, so it holds regardless
+> of the `DB_DATABASE` env var). Create it once before running:
+>
+> ```bash
+> createdb seatplus_testing        # same host/user/password as the dev DB
+> ```
+>
+> CI must provide a `seatplus_testing` database for the browser job. SQLite `:memory:`
+> is not usable (pgsql-specific migrations + the in-process browser server).

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -12,8 +12,16 @@
     <env name="APP_ENV" value="testing"/>
     <env name="BCRYPT_ROUNDS" value="4"/>
     <env name="CACHE_DRIVER" value="array"/>
-    <!-- <env name="DB_CONNECTION" value="sqlite"/> -->
-    <!-- <env name="DB_DATABASE" value=":memory:"/> -->
+    <!--
+      Dedicated test database. Tests use RefreshDatabase (migrate:fresh), so they
+      MUST NOT run against the dev database (DB_DATABASE=seatplus) or they wipe it.
+      force="true" pins the test DB regardless of any DB_DATABASE env var set by the
+      shell / dev container / CI. Create it once: `createdb seatplus_testing`
+      (same host/user/password as dev). CI must provide a `seatplus_testing` database.
+      SQLite :memory: is not usable here — pgsql-specific migrations + the Pest
+      browser in-process server sharing the connection.
+    -->
+    <env name="DB_DATABASE" value="seatplus_testing" force="true"/>
     <env name="MAIL_MAILER" value="array"/>
     <env name="QUEUE_CONNECTION" value="sync"/>
     <env name="SESSION_DRIVER" value="array"/>

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -14,3 +14,58 @@
 */
 
 uses(Tests\TestCase::class)->in('Browser');
+
+/*
+|--------------------------------------------------------------------------
+| Browser suite helpers
+|--------------------------------------------------------------------------
+|
+| Shared provisioning for the browser tests (authored in seatplus/web, executed
+| here). Lives in core's root Pest.php because that is the file Pest always loads
+| for this suite — a Pest.php synced into tests/Browser/web is not auto-loaded.
+|
+*/
+
+/**
+ * Provision a logged-in user owning a single controlled character and return it.
+ *
+ * We create ONE CharacterInfo (its factory builds the affiliation/refresh-token/role)
+ * linked as the main character rather than User::factory(), whose two-character graph
+ * has intermittently-colliding CharacterAffiliation ids and renders pages blank. Queue
+ * is faked so character-creation model events don't dispatch real ESI jobs.
+ */
+function actingAsCharacter(): \Seatplus\Eveapi\Models\Character\CharacterInfo
+{
+    \Illuminate\Support\Facades\Queue::fake();
+
+    $character = \Seatplus\Eveapi\Models\Character\CharacterInfo::factory()->create();
+
+    $user = new \Seatplus\Auth\Models\User;
+    $user->main_character_id = $character->character_id;
+    $user->save();
+
+    \Seatplus\Auth\Models\CharacterUser::create([
+        'user_id' => $user->getKey(),
+        'character_id' => $character->character_id,
+        'character_owner_hash' => sha1((string) $character->character_id),
+    ]);
+
+    \Seatplus\Web\Models\Onboarding::create(['user_id' => $user->getKey()]);
+
+    test()->actingAs($user);
+
+    return $character;
+}
+
+/**
+ * Give a character an in-game corporation role (Director by default), which grants the
+ * owning user corp-scoped access. CharacterInfo::factory() already creates an empty
+ * CharacterRole, so update it in place.
+ */
+function giveCorporationRole(\Seatplus\Eveapi\Models\Character\CharacterInfo $character, string $role = 'Director'): void
+{
+    \Seatplus\Eveapi\Models\Character\CharacterRole::updateOrCreate(
+        ['character_id' => $character->character_id],
+        ['roles' => [$role]],
+    );
+}


### PR DESCRIPTION
Core test-harness changes for the browser suite.

## Test database isolation
Tests use `RefreshDatabase` (`migrate:fresh`); `phpunit.xml` had no DB override, so they ran against `DB_DATABASE=seatplus` — the dev database — and `composer run browser` wiped it. Pin the test DB to **`seatplus_testing`** with `force="true"` (holds regardless of the `DB_DATABASE` env var). README documents the `createdb seatplus_testing` requirement.

## Browser-suite provisioning helpers
`tests/Pest.php` now defines shared helpers for the browser tests (authored in seatplus/web, executed here):
- `actingAsCharacter(): CharacterInfo` — logs in a user owning one controlled character
- `giveCorporationRole($character, 'Director')` — grants an in-game corp role

They live in core's root `Pest.php` because that is the file Pest always loads for the Browser suite (a `Pest.php` synced into `tests/Browser/web` is **not** auto-loaded). The web browser tests call these.

## ⚠️ Merge ordering
The web browser CI (`Browser (vs core)`) clones core at `5.x`, so this must merge **before** web PR #1536's browser job can go green (otherwise `actingAsCharacter()` is undefined there). Locally it already works (local core provides it).

Also: CI's browser job needs a `seatplus_testing` database available to the Postgres service.