### PR TITLE
fix: raise redis queue retry_after above the worker timeout

### DIFF
--- a/config/queue.php
+++ b/config/queue.php
@@ -66,7 +66,10 @@ return [
             'driver' => 'redis',
             'connection' => 'default',
             'queue' => env('REDIS_QUEUE', 'default'),
-            'retry_after' => 90,
+            // Must exceed the longest Horizon worker timeout (production: 900s, see
+            // EveapiServiceProvider) so a slow job (e.g. SdeImportJob's full CCP SDE
+            // import) is never re-released and double-processed into MaxAttemptsExceeded.
+            'retry_after' => (int) env('REDIS_QUEUE_RETRY_AFTER', 960),
             'block_for' => null,
             'after_commit' => false,
         ],


### PR DESCRIPTION
## Summary

`config/queue.php` set the redis connection's `retry_after` to **90s**, while:
- Horizon supervisors run with worker timeouts up to **900s** (`EveapiServiceProvider`), and
- long jobs like `SdeImportJob` set `$timeout = 600s`.

When `retry_after` is below the worker/job runtime, the queue considers a still-running job abandoned and re-releases it to another worker → the job is double-processed → `ShouldBeUnique` + attempts → `MaxAttemptsExceededException`. Laravel's own rule is that `retry_after` must be **greater than** the longest job runtime.

Raised to **960s** (comfortably above the 900s worker timeout and the 600s job timeout), overridable via a new `REDIS_QUEUE_RETRY_AFTER` env var. Removing the line isn't an option — the redis driver floors to 60s, which is worse.

This was a **latent bug for any job running 90–900s**; the SDE import was just the first one slow enough to trip it consistently. Companion to eveapi #694 (which stops the SDE import from being dispatched at migrate time and streams its download).

🤖 Generated with [Claude Code](https://claude.com/claude-code)