### PR TITLE
ci: post browser-test screenshots as an inline PR comment

### DIFF
--- a/.github/workflows/browser.yml
+++ b/.github/workflows/browser.yml
@@ -15,6 +15,10 @@ jobs:
     name: Browser Smoke Tests
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: write        # push screenshots to an orphan review branch
+      pull-requests: write   # upsert the screenshot review comment
+
     env:
       APP_ENV: testing
       DB_CONNECTION: pgsql
@@ -114,3 +118,74 @@ jobs:
           path: tests/Browser/Screenshots/
           if-no-files-found: warn
           retention-days: 7
+
+      # Publish the screenshots so they can be reviewed inline on the PR instead of
+      # downloading the zip. GitHub markdown can only embed hosted images, so push this run's
+      # PNGs to a tiny orphan branch (single force-pushed commit — no history growth; core is
+      # public so raw.githubusercontent URLs render) and build a sticky comment from them.
+      - name: Stage screenshots for the PR comment
+        id: screenshots
+        if: always() && github.event.pull_request.number != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          SRC=tests/Browser/Screenshots
+          mapfile -t shots < <(find "$SRC" -type f -name '*.png' 2>/dev/null | sort)
+          if [ ${#shots[@]} -eq 0 ]; then
+            echo "has_screenshots=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          branch="screenshots-pr-${PR}"
+          work="$(mktemp -d)"
+          for f in "${shots[@]}"; do cp "$f" "$work/$(basename "$f")"; done
+
+          git -C "$work" init -q
+          git -C "$work" checkout -q --orphan shots
+          git -C "$work" add .
+          git -C "$work" -c user.name='seatplus-ci' -c user.email='ci@seatplus.local' \
+            commit -q -m "browser screenshots for PR #${PR} (${GITHUB_SHA})"
+          git -C "$work" push -q --force \
+            "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" "shots:${branch}"
+
+          comment="$RUNNER_TEMP/screenshots-comment.md"
+          {
+            echo "<!-- browser-screenshots -->"
+            echo "## 📸 Browser test screenshots"
+            echo
+            echo "Run [#${GITHUB_RUN_ID}](https://github.com/${REPO}/actions/runs/${GITHUB_RUN_ID}) · commit \`$(echo "${GITHUB_SHA}" | cut -c1-7)\` · status **${{ job.status }}**"
+            echo
+            for f in "${shots[@]}"; do
+              base="$(basename "$f")"
+              name="$(basename "$f" .png)"
+              echo "<details><summary>${name}</summary>"
+              echo
+              echo "![${name}](https://raw.githubusercontent.com/${REPO}/${branch}/${base})"
+              echo
+              echo "</details>"
+            done
+          } > "$comment"
+
+          echo "has_screenshots=true" >> "$GITHUB_OUTPUT"
+          echo "comment_path=$comment" >> "$GITHUB_OUTPUT"
+
+      - name: Find existing screenshot comment
+        id: find_comment
+        if: always() && steps.screenshots.outputs.has_screenshots == 'true'
+        uses: peter-evans/find-comment@v3
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: '<!-- browser-screenshots -->'
+
+      - name: Upsert screenshot comment
+        if: always() && steps.screenshots.outputs.has_screenshots == 'true'
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ steps.find_comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body-path: ${{ steps.screenshots.outputs.comment_path }}
+          edit-mode: replace

--- a/.github/workflows/cleanup-screenshots.yml
+++ b/.github/workflows/cleanup-screenshots.yml
@@ -1,0 +1,23 @@
+name: Cleanup screenshots
+
+# When a PR closes, drop the throwaway orphan branch that held its browser screenshots
+# (created by the Browser workflow) so screenshots-pr-* branches don't accumulate.
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+
+jobs:
+  delete-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete the PR's screenshot branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api -X DELETE \
+            "repos/${{ github.repository }}/git/refs/heads/screenshots-pr-${{ github.event.pull_request.number }}" \
+            && echo "deleted screenshots-pr-${{ github.event.pull_request.number }}" \
+            || echo "no screenshot branch for PR #${{ github.event.pull_request.number }}"


### PR DESCRIPTION
## Summary

Browser-test screenshots were only uploaded as a zip artifact, so reviewing them meant downloading the zip. This publishes them **inline on the PR** instead.

GitHub markdown can't embed a zip or local files, so on each PR run the `Browser` workflow now:

1. Pushes this run's `tests/Browser/Screenshots/*.png` to a throwaway **orphan branch `screenshots-pr-<n>`** — a single force-pushed commit, so there's **no repo-history growth**. core is public, so `raw.githubusercontent.com` URLs render.
2. **Upserts a sticky PR comment** (`peter-evans/find-comment` + `create-or-update-comment`, already used in `regression.yml`) embedding each screenshot in a collapsible `<details>` block, with the run link, short commit, and job status.

A companion **`cleanup-screenshots.yml`** deletes `screenshots-pr-<n>` when the PR closes, so those branches don't accumulate.

The zip artifact is kept as a fallback (and for non-PR runs). Screenshots post even on failed runs (`if: always()`) so you can review what broke.

## Notes / caveats
- New job permissions: `contents: write` (push the orphan branch) + `pull-requests: write` (comment).
- The comment step needs a **pull_request-context** run (it reads `github.event.pull_request.number`); a bare `workflow_dispatch` won't have the PR number. Re-running a PR's Browser check works.
- **Bot-created PRs** (e.g. the auto bump PR): GitHub doesn't auto-run `pull_request` workflows for PRs opened by the `github-actions` bot (loop-prevention) — which is why they must be run manually. Can add a `workflow_dispatch` PR-number input if you want that path too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)