### PR TITLE
test: real EVE character id for the logged-in browser-test character

### DIFF
--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -38,7 +38,18 @@ function actingAsCharacter(): \Seatplus\Eveapi\Models\Character\CharacterInfo
 {
     \Illuminate\Support\Facades\Queue::fake();
 
-    $character = \Seatplus\Eveapi\Models\Character\CharacterInfo::factory()->create();
+    // Use a real EVE character id so images.evetech.net serves an actual portrait in browser-test
+    // screenshots instead of the generic default it returns for fabricated ids. Pick one from the
+    // pool (real GSF members) not already taken in this RefreshDatabase-isolated test — so repeated
+    // logins/characters vary — and fall back to the factory's random id if the pool is exhausted.
+    $realCharacterIds = [240070320, 197343093, 1319140135, 92081232, 94391213, 887625289, 1435633555, 1809892636];
+    $availableCharacterIds = array_values(array_diff(
+        $realCharacterIds,
+        \Seatplus\Eveapi\Models\Character\CharacterInfo::query()->pluck('character_id')->all()
+    ));
+
+    $character = \Seatplus\Eveapi\Models\Character\CharacterInfo::factory()
+        ->create($availableCharacterIds ? ['character_id' => $availableCharacterIds[0]] : []);
 
     $user = new \Seatplus\Auth\Models\User;
     $user->main_character_id = $character->character_id;

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -42,7 +42,7 @@ function actingAsCharacter(): \Seatplus\Eveapi\Models\Character\CharacterInfo
     // screenshots instead of the generic default it returns for fabricated ids. Pick one from the
     // pool (real GSF members) not already taken in this RefreshDatabase-isolated test — so repeated
     // logins/characters vary — and fall back to the factory's random id if the pool is exhausted.
-    $realCharacterIds = [240070320, 197343093, 1319140135, 92081232, 94391213, 887625289, 1435633555, 1809892636];
+    $realCharacterIds = \Illuminate\Support\Arr::shuffle([240070320, 197343093, 1319140135, 92081232, 94391213, 887625289, 1435633555, 1809892636]);
     $availableCharacterIds = array_values(array_diff(
         $realCharacterIds,
         \Seatplus\Eveapi\Models\Character\CharacterInfo::query()->pluck('character_id')->all()


### PR DESCRIPTION
## What

`actingAsCharacter()` (the browser-test login helper) created the logged-in character with a **fabricated** id. `images.evetech.net` returns a generic default portrait for ids that don't exist, so the logged-in character's avatar — shown on the dashboard and in the sidebar footer on **every** page — rendered image-less in the browser-test screenshots (the screenshot-comment workflow).

This uses a **real** character id (`240070320`, a GSF founder) so a real portrait resolves, falling back to the factory's random id if it's already taken (e.g. a test that logs in twice) — collision-safe.

## Why separate / non-blocking

The counterpart change for contract/mail/asset **counterparties** lives in seatplus/web **#1570** and is independent. This PR only affects the *logged-in* character (provisioned here in core), so it's split out and does **not** block #1570. The Browser (vs core) job clones core at `5.x`, so this needs to land on `5.x` for the screenshots to pick it up.

## Effect

Portraits resolve for real in the browser-test screenshots instead of the CDN's default placeholder. Test behaviour is otherwise unchanged (the id value isn't asserted anywhere).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
