### PR TITLE
test(browser): drop helpers now shared in web's helpers.php

### DIFF
--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -20,63 +20,12 @@ uses(Tests\TestCase::class)->in('Browser');
 | Browser suite helpers
 |--------------------------------------------------------------------------
 |
-| Shared provisioning for the browser tests (authored in seatplus/web, executed
-| here). Lives in core's root Pest.php because that is the file Pest always loads
-| for this suite — a Pest.php synced into tests/Browser/web is not auto-loaded.
+| The suite's provisioning + seeding helpers (actingAsCharacter, snap, the
+| make/seed factories, …) live in tests/Browser/web/helpers.php, authored and
+| shipped alongside the tests in the seatplus/web package and synced into core
+| with them. Each browser test file `require_once`s that shared file directly,
+| so nothing needs to be declared here — Pest only auto-loads this ROOT Pest.php
+| (a Pest.php synced into tests/Browser/web is never loaded), which is why the
+| suite binding above stays here while the helpers travel with the tests.
 |
 */
-
-/**
- * Provision a logged-in user owning a single controlled character and return it.
- *
- * We create ONE CharacterInfo (its factory builds the affiliation/refresh-token/role)
- * linked as the main character rather than User::factory(), whose two-character graph
- * has intermittently-colliding CharacterAffiliation ids and renders pages blank. Queue
- * is faked so character-creation model events don't dispatch real ESI jobs.
- */
-function actingAsCharacter(): \Seatplus\Eveapi\Models\Character\CharacterInfo
-{
-    \Illuminate\Support\Facades\Queue::fake();
-
-    // Use a real EVE character id so images.evetech.net serves an actual portrait in browser-test
-    // screenshots instead of the generic default it returns for fabricated ids. Pick one from the
-    // pool (real GSF members) not already taken in this RefreshDatabase-isolated test — so repeated
-    // logins/characters vary — and fall back to the factory's random id if the pool is exhausted.
-    $realCharacterIds = \Illuminate\Support\Arr::shuffle([240070320, 197343093, 1319140135, 92081232, 94391213, 887625289, 1435633555, 1809892636]);
-    $availableCharacterIds = array_values(array_diff(
-        $realCharacterIds,
-        \Seatplus\Eveapi\Models\Character\CharacterInfo::query()->pluck('character_id')->all()
-    ));
-
-    $character = \Seatplus\Eveapi\Models\Character\CharacterInfo::factory()
-        ->create($availableCharacterIds ? ['character_id' => $availableCharacterIds[0]] : []);
-
-    $user = new \Seatplus\Auth\Models\User;
-    $user->main_character_id = $character->character_id;
-    $user->save();
-
-    \Seatplus\Auth\Models\CharacterUser::create([
-        'user_id' => $user->getKey(),
-        'character_id' => $character->character_id,
-        'character_owner_hash' => sha1((string) $character->character_id),
-    ]);
-
-    \Seatplus\Web\Models\Onboarding::create(['user_id' => $user->getKey()]);
-
-    test()->actingAs($user);
-
-    return $character;
-}
-
-/**
- * Give a character an in-game corporation role (Director by default), which grants the
- * owning user corp-scoped access. CharacterInfo::factory() already creates an empty
- * CharacterRole, so update it in place.
- */
-function giveCorporationRole(\Seatplus\Eveapi\Models\Character\CharacterInfo $character, string $role = 'Director'): void
-{
-    \Seatplus\Eveapi\Models\Character\CharacterRole::updateOrCreate(
-        ['character_id' => $character->character_id],
-        ['roles' => [$role]],
-    );
-}


### PR DESCRIPTION
## What

Removes the two browser-suite helpers (`actingAsCharacter`, `giveCorporationRole`) that were declared in the root `tests/Pest.php`. They — and every other suite helper — now live in the **seatplus/web** package's `tests/Browser/helpers.php`, which each browser test `require_once`s and which syncs into `tests/Browser/web/` alongside the tests.

Companion to **seatplus/web#1606** (the helpers extraction). Also fixes a comment typo where `make*/seed*` closed the `/* */` block early (`*/`), which produced a parse error in `tests/Pest.php`.

## Why safe

- Core has no native browser tests — only the synced `web/` copy uses these helpers, and it now brings its own `helpers.php`.
- web's `helpers.php` keeps a `function_exists` guard on both, so a web release predating this change coexists without a redeclare fatal.

## Sequencing

Land **after** web#1606 is released/picked up, so the synced `tests/Browser/web/helpers.php` carries the definitions this file stops providing. (Until then core's committed `Pest.php` still declared them, and web's guard made the two coexist — so there is no rush and no breakage window if merged in order.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)