### PR TITLE
docs(claude): conventions — snake_case props, browser screenshot matrix, host browser tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,10 +219,18 @@ Follow the [Spatie PHP/Laravel guidelines](https://spatie.be/guidelines/laravel)
 - **Comments** explain *why*, not *what*.
 - **File headers:** do **not** add the MIT license header block to new files — start directly with `<?php` (+ `declare(strict_types=1);` / `namespace`). Legacy files still carry the header; leave those as-is unless editing for another reason.
 
-> Note: the codebase currently uses **snake_case local variables** widely, which
-> conflicts with the Spatie camelCase rule. A project-wide camelCase
-> standardization is tracked as a separate effort — follow the existing
-> snake_case for consistency until it lands.
+> **snake_case props & payload keys are intentional, not tech-debt.** Vue props,
+> Inertia page props, and `router` data keys mirror the PHP controller payloads
+> (`character_ids`, `ref_types`, `available_scopes`, …), so they stay snake_case
+> to preserve the controller↔component contract; renaming them would require
+> backend changes. `vue/prop-name-casing` stays enabled — add a targeted
+> `// eslint-disable-next-line vue/prop-name-casing -- <reason>` on those props
+> (see `Pages/Character/Wallet/Index.vue`) rather than disabling the rule globally.
+>
+> Separately, the codebase uses **snake_case *local* variables** (`filtered_items`,
+> `image_class`, …) widely, which conflicts with the Spatie camelCase rule. That
+> is legacy tech-debt: a project-wide camelCase standardization is tracked as a
+> separate effort — follow the existing snake_case for consistency until it lands.
 
 ## Key configuration
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,6 +182,12 @@ non-negotiable — the dev shell/container exports `DB_DATABASE=seatplus`, and w
 `migrate:fresh` against the **dev** database and wipes it. Tests must never touch
 `seatplus`. Browser tests run in core against the `laravel` DB too.
 
+**Browser screenshot tests** (web `tests/Browser/`): the `snap($page, $name)` helper
+captures a screenshot rendered in CI as a **Desktop | iPhone** table. Capture **both**
+viewports — parametrize the test `->with(['desktop', 'iphone'])`, build the page with
+`deviceVisit($device, $url)` (not bare `visit()`), and name the snap `"…-{$device}"`. A
+desktop-only `snap()` leaves an empty iPhone cell in the matrix.
+
 Root-level tests (array cache + sync queue, no PostgreSQL): `./vendor/bin/phpunit`.
 **100% type coverage is enforced** (`pest --type-coverage --min=100`); all packages
 also enforce PHPStan/Larastan and Pint (PSR-12). Run the specific changed test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,6 +188,12 @@ viewports — parametrize the test `->with(['desktop', 'iphone'])`, build the pa
 `deviceVisit($device, $url)` (not bare `visit()`), and name the snap `"…-{$device}"`. A
 desktop-only `snap()` leaves an empty iPhone cell in the matrix.
 
+**Running browser tests:** they run on the **host Mac** (Pest 4 + Playwright) or in CI's
+"Browser (vs core)" job — the dev container has no browser, so they cannot run in-container.
+To run them on the host, the branch must be checked out in the **real `packages/web`
+working copy**; an agent's `git worktree` under `.claude/worktrees/` isn't where the host
+runner looks, so check the branch out in the main checkout first.
+
 Root-level tests (array cache + sync queue, no PostgreSQL): `./vendor/bin/phpunit`.
 **100% type coverage is enforced** (`pest --type-coverage --min=100`); all packages
 also enforce PHPStan/Larastan and Pint (PSR-12). Run the specific changed test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,6 +217,7 @@ Follow the [Spatie PHP/Laravel guidelines](https://spatie.be/guidelines/laravel)
 - **Control flow:** curly braces always; happy-path last with early-return guards; avoid `else`; prefer separate `if`s over compound `&&`/`||`.
 - **Docblocks** only when they add context beyond the signature; array-shape types `@param array{name: string} $x`.
 - **Comments** explain *why*, not *what*.
+- **File headers:** do **not** add the MIT license header block to new files — start directly with `<?php` (+ `declare(strict_types=1);` / `namespace`). Legacy files still carry the header; leave those as-is unless editing for another reason.
 
 > Note: the codebase currently uses **snake_case local variables** widely, which
 > conflicts with the Spatie camelCase rule. A project-wide camelCase


### PR DESCRIPTION
Four clarifications to `CLAUDE.md`, surfaced while migrating the web package to `<script setup>` and fixing Frontend Lint:

- **File headers** — new PHP files skip the MIT license header block (start at `<?php`); legacy files keep theirs.
- **snake_case props are intentional, not tech-debt** — Vue props / Inertia page props / `router` data keys mirror the PHP controller payloads (`character_ids`, `ref_types`, …), so they stay snake_case to preserve the controller↔component contract. `vue/prop-name-casing` stays on; use a targeted per-prop `eslint-disable` + reason. (Distinct from snake_case *local variables*, which remain the tracked camelCase tech-debt.)
- **Desktop | iPhone screenshot convention** — browser `snap()` tests must capture both viewports: parametrize `->with(['desktop','iphone'])`, build the page via `deviceVisit($device, …)` (not bare `visit()`), name snaps `…-{$device}`. A desktop-only snap leaves an empty iPhone cell in the CI matrix.
- **Running browser tests** — Pest 4 + Playwright run on the host Mac or CI's "Browser (vs core)" job, never in the browserless dev container; to run locally the branch must be in the real `packages/web` checkout, not an agent `.claude/worktrees/` worktree.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)