### PR TITLE
ci(regression): open the bump PR with the release App token

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -125,11 +125,35 @@ jobs:
           if-no-files-found: warn
           retention-days: 7
 
+      # A PR opened with the default GITHUB_TOKEN never fires `pull_request` events —
+      # GitHub's recursion guard — so browser.yml would skip the bump PR entirely and it
+      # would land with zero checks. Mint a short-lived installation token instead so the
+      # PR is authored by the app and CI treats it like any human PR.
+      # Reuses the same release app as esi-schema (vars.RELEASE_APP_ID +
+      # secrets.RELEASE_APP_PRIVATE_KEY); it needs contents + pull-requests write on core.
+      # continue-on-error: if the app is ever missing here this degrades to the old
+      # GITHUB_TOKEN behaviour (PR opens, no checks) rather than failing the regression run.
+      - name: Mint an App token
+        id: app-token
+        if: steps.changed.outputs.changed == 'true'
+        continue-on-error: true
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
+      - name: Warn when the App token is unavailable
+        if: steps.changed.outputs.changed == 'true' && steps.app-token.outputs.token == ''
+        run: |
+          echo "::warning::RELEASE_APP_ID / RELEASE_APP_PRIVATE_KEY unavailable — \
+          falling back to GITHUB_TOKEN, so the bump PR will not trigger any workflows."
+
       # Reached only if the suite passed (a failing suite fails the job = regression alert).
       - name: Open bump PR
         if: steps.changed.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v6
         with:
+          token: ${{ steps.app-token.outputs.token || github.token }}
           commit-message: "chore: bump seatplus/* to latest release"
           title: "chore: bump seatplus/* to latest release"
           branch: chore/seatplus-bump


### PR DESCRIPTION
The nightly bump PR (#241 being the current one) lands with **zero checks**: it is
opened by `peter-evans/create-pull-request` using the default `GITHUB_TOKEN`, and
GitHub deliberately does not fire `pull_request` events for anything created with
that token (recursion guard). `browser.yml` has a bare `pull_request:` trigger with
no path filter, so it would happily run — it simply never gets an event.

Mint a short-lived installation token from the same release App `esi-schema`
already uses (`vars.RELEASE_APP_ID` + `secrets.RELEASE_APP_PRIVATE_KEY`) and hand
it to `create-pull-request`, so the PR is authored by the App and CI treats it like
any other PR.

The token step is `continue-on-error` with a `|| github.token` fallback and a
warning annotation: if the App is ever unavailable, the regression run still
completes and still opens the PR — it just goes back to being uncheckable, rather
than failing after a full browser suite has already passed.

### Prerequisites on the App

- installed on `seatplus/core` (installation is per-repository, even org-wide)
- **Pull requests: write** in addition to Contents: write — `esi-schema` only pushes
  commits and tags, so the App may have been created Contents-only

### After merge

`gh workflow run regression.yml` pushes to `chore/seatplus-bump` as the App; that
`synchronize` event gives #241 its Browser checks and screenshot comment. If the
lock resolves byte-identical to what is already on that branch there is no new
commit and hence no event — close/reopen #241 that one time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)