### PR TITLE
ci(browser): stop the screenshot comment aborting on an empty array

### DIFF
--- a/.github/workflows/browser.yml
+++ b/.github/workflows/browser.yml
@@ -154,7 +154,10 @@ jobs:
           # Pair screenshots by view name: files are named "<view>-desktop.png" / "<view>-iphone.png"
           # (see snap() in the browser tests), so group them into one row per view with a Desktop and
           # an iPhone column. Anything without a device suffix is listed underneath.
-          declare -A desktop_url iphone_url other_url
+          # Assign `=()` rather than just declaring: a declared-but-never-assigned array
+          # still counts as unset, so under `set -u` the ${#other_url[@]} guard below
+          # aborts the step whenever every screenshot carries a device suffix — i.e. always.
+          declare -A desktop_url=() iphone_url=() other_url=()
           for f in "${shots[@]}"; do
             base="$(basename "$f")"
             name="$(basename "$f" .png)"


### PR DESCRIPTION
The Browser job on #241 ([run 32000970952](https://github.com/seatplus/core/actions/runs/32000970952))
went red **after** a fully green browser suite — the failure is in
*Stage screenshots for the PR comment*:

```
line 55: other_url: unbound variable
```

`declare -A other_url` declares the array but leaves it unset until something is
assigned to it, so under `set -u` the `${#other_url[@]} -gt 0` guard aborts
instead of reporting 0. `other_url` only collects screenshots without a
`-desktop`/`-iphone` suffix, and `snap()` always adds one — so this fires on
every PR with well-formed screenshot names. It has been broken since 30100b5
introduced the table; #241 is simply the first PR to reach that step.

Assigning `=()` marks the arrays as set. `desktop_url`/`iphone_url` get the same
treatment: they would hit it at the `${!desktop_url[@]}` expansion in the (rarer)
case of a run producing only unsuffixed shots.

Self-verifying: this PR triggers `browser.yml` itself, so a green *Browser Smoke
Tests* here — with a screenshot comment below — is the proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)