### PR TITLE
fix: generate Wayfinder output in the php container, not the vite build

### DIFF
--- a/.github/workflows/browser.yml
+++ b/.github/workflows/browser.yml
@@ -77,10 +77,15 @@ jobs:
 
       # The web package's frontend (package.json, vite/tailwind/postcss configs,
       # resources/js, css) is published into core, not committed.
+      # `wayfinder:generate` is what produces @/actions and @/routes. It has to run
+      # here, on the php-equipped runner: the vite build no longer generates it (the
+      # production node container has no php binary — seatplus/web#1678), so this is
+      # the same step base-app gets from core's post-update-cmd.
       - name: Publish web package assets
         run: |
           php artisan vendor:publish --tag=web-static --force
           php artisan vendor:publish --tag=web --force
+          php artisan wayfinder:generate
 
       # Browser tests are authored in the web package and shipped in its dist;
       # run them here against the assembled app (no-op until web ships tests/Browser).
@@ -96,6 +101,11 @@ jobs:
         with:
           node-version: '22'
 
+      # TODO(seatplus/web#1678): once a web release carrying fa5b153a is pinned here,
+      # drop the ad hoc install and use `npm install` + `npm run playwright:install` —
+      # web's package.json then declares `playwright` at an exact version, and installing
+      # it here would override that pin. Until then the released package.json (5.0.1)
+      # declares no playwright at all, so CI has to supply the driver itself.
       - name: Install npm dependencies + Playwright driver
         run: |
           npm install

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -89,6 +89,9 @@ jobs:
           php artisan key:generate
           php artisan vendor:publish --tag=web-static --force
           php artisan vendor:publish --tag=web --force
+          # Produces @/actions + @/routes. Must run on this php-equipped runner: the
+          # vite build no longer shells out to php (seatplus/web#1678).
+          php artisan wayfinder:generate
 
       - name: Pull in web-owned browser tests
         if: steps.changed.outputs.changed == 'true'
@@ -104,6 +107,10 @@ jobs:
         with:
           node-version: '22'
 
+      # TODO(seatplus/web#1678): swap the ad hoc driver install for
+      # `npm run playwright:install` once a web release carrying fa5b153a is pinned —
+      # see the same note in browser.yml. Note this job runs `composer update seatplus/*`,
+      # so it is the first place the newer package.json will land.
       - name: Build assets + Playwright
         if: steps.changed.outputs.changed == 'true'
         run: |

--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,8 @@
             "@php artisan lang:publish",
             "@php artisan vendor:publish --tag=laravel-assets --ansi --force",
             "@php artisan vendor:publish --tag=web-static --force",
-            "@php artisan vendor:publish --tag=web --force"
+            "@php artisan vendor:publish --tag=web --force",
+            "@php artisan wayfinder:generate"
         ],
         "local:on": "@php local-packages.php on",
         "local:off": "@php local-packages.php off",


### PR DESCRIPTION
Companion to **seatplus/web#1681**, which fixes seatplus/web#1678 (Seatplus 5.1 release train, step 4). Land both.

## Why

base-app's node service is `node:current-alpine` — **no php binary** — but `@/actions` and `@/routes` were only ever produced by a vite build-startup hook shelling out to `php artisan wayfinder:generate`. So `docker-compose restart node` → `npm run prod` → `php: not found` → build dies on unresolved imports.

web#1681 marks those vite runners `build: false` so the build never touches php. This PR is the other half: **produce the output where php actually lives.**

## Changes

**`composer.json`** — add `@php artisan wayfinder:generate` to `post-update-cmd`, next to the existing `vendor:publish` calls. `laravel/wayfinder` sits in web's `require` (not `require-dev`), so the command is present under `composer update --no-dev` — exactly what the update docs already tell users to run inside `exec php`.

**`browser.yml` / `regression.yml`** — both got `@/actions` *implicitly*, from the vite startup hook on a php-equipped runner. That's precisely why this bug stayed invisible: CI never ran the path a user runs. Generate it explicitly now, mirroring what base-app gets from `post-update-cmd`. Needed independently of the composer change, since `--no-scripts` means `post-update-cmd` never fires in CI.

## The Playwright cleanup is deferred — it can't land yet

The issue asks for the ad hoc `npm install --save-dev playwright` to be replaced with `npm run playwright:install` here. I tried it; **CI proved it impossible right now**:

```
npm error Missing script: "playwright:install"
```

web added both the `playwright` devDependency and that script in `fa5b153a` (2026-08-03), and `git tag --contains fa5b153a` is **empty** — it's in no released tag, not 5.0.1 (pinned in our lock) nor 5.0.2. The released `package.json` declares no `playwright` at all, so these workflows genuinely have to supply the driver themselves. "core never got the memo" is right in intent, but the memo isn't published yet.

So both workflows keep the ad hoc install, with a `TODO(seatplus/web#1678)` marking the swap for once a web release carrying `fa5b153a` is pinned here — at which point the ad hoc install flips from *necessary* to *harmful*, since it would override the exact `playwright` pin web#1681 adds. `regression.yml` runs `composer update "seatplus/*"`, so it's the first place the newer `package.json` will land.

## Verification

`composer.json` valid JSON, both workflows valid YAML. More usefully, the first CI run on this branch already **confirms the load-bearing change works**: `Publish web package assets` (now including `wayfinder:generate`) and `Build assets` both passed — it failed only on the Playwright step now reverted above.

The end-to-end proof remains the PHP-less build leg of the release preflight (step 8).

## Coverage — what this fixes, and what it does not

Every path that reaches a frontend build, after this PR plus seatplus/web#1681:

| path | generates before the build? | |
|---|---|---|
| docs `update.md` — `composer update --no-dev` then `docker-compose restart node` | yes, via `post-update-cmd` | **fixed** |
| this repo's `browser.yml` / `regression.yml`, and web's `laravel.yml` | yes, explicit workflow step | **fixed**, green |
| local dev `npm run dev` | yes, the vite hook is still live under `serve` | fine |
| `.devcontainer` (`composer install`) | no | fine — backend-only by design, "Do NOT run npm/vite here" |
| docs `installation.md` — `composer create-project` then `up -d` | **no hook fires at all** | **still broken** — #270 |

The last row is a separate, pre-existing bug: `create-project` runs an *install*, so it dispatches `post-install-cmd` (which this repo does not have) and never `post-update-cmd`. That means the existing `vendor:publish --tag=web-static` does not run on a fresh install either, so there is no `package.json` and the node container's `npm install && npm run prod` fails before `@/actions` is ever resolved. Filed as #270 — worth knowing that merging this PR does **not** mean a fresh 5.1 install builds.

The deferred Playwright swap is tracked in #271.

## Ordering note

web#1681 is what makes the vite hook stop generating. Until web ships that, this PR is harmless and additive — the explicit step just does what the hook already did, earlier and reliably. Once web#1681 is released, this PR is **required**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)